### PR TITLE
cargo 1.46 wouldn't build without this

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ serde = { version = "1.0", features = ["derive"] }
 
 [dependencies.clap]
 version = "2.33.0"
+features = ["yaml"]
 default-features = false


### PR DESCRIPTION
```
> cargo build --release
    Updating crates.io index
error: failed to get `clap` as a dependency of package `ffmpeg-lh v0.1.0 (/home/X/ffmpeg-loudnorm-helper)`

Caused by:
  failed to fetch `https://github.com/rust-lang/crates.io-index`

Caused by:
  error inflating zlib stream; class=Zlib (5)
```